### PR TITLE
Added Checkstyle to validate code style

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,41 @@
                 <artifactId>maven-project-info-reports-plugin</artifactId>
                 <version>3.0.0</version>
             </plugin>
+            <!-- Following the instructions here to setup code autoformatting will be useful
+             in addressing checkstyle failures - https://github.com/google/google-java-format
+             #intellij-android-studio-and-other-jetbrains-ides
+             -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.1.1</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.puppycrawl.tools</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>8.38</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <configLocation>google_checks.xml</configLocation>
+                    <!--  <suppressionsLocation>suppressions.xml</suppressionsLocation> -->
+                    <encoding>UTF-8</encoding>
+                    <violationSeverity>warning</violationSeverity>
+                    <failsOnError>true</failsOnError>
+                    <failOnViolation>true</failOnViolation>
+                    <consoleOutput>true</consoleOutput>
+                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/test/java/tests/ExceptionClassConverterTest.java
+++ b/src/test/java/tests/ExceptionClassConverterTest.java
@@ -11,7 +11,8 @@ import parameterconverters.ExceptionClassConverter;
 public class ExceptionClassConverterTest {
 
   /**
-   * Tests parameterconverters.ExceptionClassConverter::convertExceptionNameToClass() with invalid inputs.
+   * Tests parameterconverters.ExceptionClassConverter::convertExceptionNameToClass() with
+   * invalid inputs.
    */
   @Test
   public void testConvertExceptionNameToClassWithInvalidInputs() {
@@ -30,7 +31,8 @@ public class ExceptionClassConverterTest {
   }
 
   /**
-   * Tests parameterconverters.ExceptionClassConverter::convertExceptionNameToClass() with valid inputs.
+   * Tests parameterconverters.ExceptionClassConverter::convertExceptionNameToClass() with
+   * valid inputs.
    */
   @Test
   public void testConvertExceptionNameToClassWithValidInputs() {


### PR DESCRIPTION
Closes #2.
Checkstyle has been configured to use the Google Java styling guidelines.
To enforce the check, add "checkstyle:check" to the mvn command while
building the project.