### PR TITLE
Added property utility

### DIFF
--- a/src/main/java/utilities/PropertyUtility.java
+++ b/src/main/java/utilities/PropertyUtility.java
@@ -1,0 +1,144 @@
+package utilities;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Used to load property values from pre-specified files.
+ */
+public class PropertyUtility {
+  /**
+   * Note: Cannot internationalize PropertyUtility class because I18NUtility class depends on this.
+   */
+  private static final Logger logger = LogManager.getLogger(PropertyUtility.class);
+  private static final Map<Class<?>, HashMap<String, Properties>> classToPropertyFilesMap =
+      Collections.synchronizedMap(new HashMap<>());
+
+  /**
+   * Utility class which doesn't need to be instantiated, hence the constructor is private.
+   */
+  private PropertyUtility() {}
+
+  /**
+   * Retrieves the value corresponding to the property key specified. If multiple property files
+   * contain the same key, the first property file (Decided by the order in which the property file
+   * is added) in which the property is present is used.
+   *
+   * @param propertyKey The property key to retrieve the value for
+   * @return The value corresponding to the property specified
+   */
+  public static synchronized String getProperty(String propertyKey) {
+    // Input validation
+    Objects.requireNonNull(propertyKey);
+
+    Properties propertiesObj =
+        classToPropertyFilesMap.keySet().stream()
+            .map(
+                cls -> {
+                  HashMap<String, Properties> propertiesForSpecificClassMap =
+                      classToPropertyFilesMap.getOrDefault(cls, null);
+                  return propertiesForSpecificClassMap.values().parallelStream()
+                      .filter(properties -> properties.containsKey(propertyKey))
+                      .findFirst()
+                      .orElse(null);
+                })
+            .filter(Objects::nonNull)
+            .findFirst()
+            .orElseThrow();
+    return propertiesObj.getProperty(propertyKey);
+  }
+
+  /**
+   * Retrieves the value corresponding to the property key specified in the desired type.
+   * If multiple property files contain the same key, the first property file (Decided by
+   * the order in which the property file is added) in which the property is present is used.
+   *
+   * @param typeClass The class object of the desired return type.
+   * @param propertyKey The property key to retrieve the value for.
+   * @param <T> The type used to cast the property value.
+   * @return The value corresponding to the property specified
+   */
+  @SuppressWarnings("unchecked")
+  public static synchronized <T> T getTypedProperty(Class<T> typeClass, String propertyKey) {
+    // Input validation
+    Objects.requireNonNull(typeClass);
+    Objects.requireNonNull(propertyKey);
+
+    String propertyValueString = getProperty(propertyKey);
+    if (typeClass == Boolean.class) {
+      return (T) Boolean.valueOf(propertyValueString);
+    } else if (typeClass == Byte.class) {
+      return (T) Byte.valueOf(propertyValueString);
+    } else if (typeClass == Short.class) {
+      return (T) Short.valueOf(propertyValueString);
+    } else if (typeClass == Integer.class) {
+      return (T) Integer.valueOf(propertyValueString);
+    } else if (typeClass == Long.class) {
+      return (T) Long.valueOf(propertyValueString);
+    } else if (typeClass == Float.class) {
+      return (T) Float.valueOf(propertyValueString);
+    } else if (typeClass == Double.class) {
+      return (T) Double.valueOf(propertyValueString);
+    } else {
+      throw new IllegalArgumentException("Unknown type class (" + typeClass + ")");
+    }
+  }
+
+  /**
+   * Add a specified property file.
+   *
+   * @param cls Class to use to load the property file.
+   * @param propertyFileName Name of the property file to add.
+   * @throws IOException When there is an issue loading the properties file.
+   */
+  public static synchronized void addPropertyFile(Class<?> cls, String propertyFileName)
+      throws IOException {
+    Properties properties;
+    try (final InputStream inputStream = cls.getResourceAsStream(propertyFileName)) {
+      properties = new Properties();
+      properties.load(inputStream);
+    }
+    classToPropertyFilesMap.putIfAbsent(cls, new HashMap<>());
+    HashMap<String, Properties> propertiesForSpecificClassMap = classToPropertyFilesMap.get(cls);
+    if (propertiesForSpecificClassMap.containsKey(propertyFileName)) {
+      logger.warn("Adding a property file (" + propertyFileName + ") "
+          + "again using class (" + cls + ")");
+    }
+    propertiesForSpecificClassMap.put(propertyFileName, properties);
+  }
+
+  /**
+   * Remove a specified property file.
+   *
+   * @param cls Class whose property file needs to be removed.
+   * @param propertyFileName name of the property file to remove.
+   */
+  public static synchronized void removePropertyFile(Class<?> cls, String propertyFileName) {
+    // Input validation
+    Objects.requireNonNull(cls);
+    Objects.requireNonNull(propertyFileName);
+
+    if (!classToPropertyFilesMap.containsKey(cls)) {
+      logger.warn("No property files loaded for the specified class (" + cls + ")");
+    } else {
+      HashMap<String, Properties> propertiesForSpecificClassMap = classToPropertyFilesMap.get(cls);
+      if (!propertiesForSpecificClassMap.containsKey(propertyFileName)) {
+        logger.warn(
+            "Specified property file ("
+                + propertyFileName
+                + ") hasn't been loaded for the specified class ("
+                + cls
+                + "). Hence it cannot be removed.");
+      } else {
+        propertiesForSpecificClassMap.remove(propertyFileName);
+      }
+    }
+  }
+}

--- a/src/main/java/wordspackage/WordCounter.java
+++ b/src/main/java/wordspackage/WordCounter.java
@@ -1,9 +1,11 @@
 package wordspackage;
 
+import java.io.IOException;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.validation.constraints.NotNull;
+import utilities.PropertyUtility;
 
 /**
  * Provides functionality to count words in a string.
@@ -20,14 +22,18 @@ public final class WordCounter {
    *
    * @param str String to compute word count.
    * @return The number of words in the input string
+   * @throws IOException When there is an issue loading the properties file.
    */
-  public static long getWordCount(@NotNull final String str) {
+  public static long getWordCount(@NotNull final String str) throws IOException {
     Objects.requireNonNull(str);
+
+    PropertyUtility.addPropertyFile(WordCounter.class, "WordCounter.properties");
 
     long wordCount = 0;
     if (str.length() != 0) {
       wordCount = 1;
-      Matcher matcher = Pattern.compile("\\s+").matcher(str.trim());
+      String wordSeparatorRegex = PropertyUtility.getProperty("string.regex.wordSeparator");
+      Matcher matcher = Pattern.compile(wordSeparatorRegex).matcher(str.trim());
       while (matcher.find()) {
         wordCount++;
       }

--- a/src/main/resources/wordspackage/WordCounter.properties
+++ b/src/main/resources/wordspackage/WordCounter.properties
@@ -1,0 +1,1 @@
+string.regex.wordSeparator=\\s+

--- a/src/test/java/tests/PropertyUtilityTest.java
+++ b/src/test/java/tests/PropertyUtilityTest.java
@@ -1,0 +1,204 @@
+package tests;
+
+import java.io.IOException;
+import java.util.NoSuchElementException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import utilities.PropertyUtility;
+
+class PropertyUtilityTest {
+
+  /**
+   * Loads the necessary property file for testing.
+   *
+   * @throws IOException When there is an issue loading the property file.
+   */
+  @BeforeAll
+  static void setup() throws IOException {
+    PropertyUtility.addPropertyFile(PropertyUtilityTest.class, "test.properties");
+  }
+
+  /**
+   * Test retrieving the value for a valid property key.
+   */
+  @Test
+  void testGetStringWithValidProperty() {
+    Assertions.assertEquals(
+        "TEST1", PropertyUtility.getProperty("test1")
+    );
+  }
+
+  /**
+   * Test retrieving the value for an invalid property key.
+   */
+  @Test
+  void testGetStringWithInvalidProperty() {
+    Assertions.assertThrows(
+        NoSuchElementException.class, () -> PropertyUtility.getProperty("test_invalid")
+    );
+    // Null input
+    Assertions.assertThrows(
+        NullPointerException.class, () -> PropertyUtility.getProperty(null)
+    );
+  }
+
+  /**
+   * Test adding a valid properties file.
+   *
+   * @throws IOException When there is an issue loading the property file.
+   */
+  @Test
+  void testAddPropertyFileWithValidInputs() throws IOException {
+    // Add property file again.
+    PropertyUtility.addPropertyFile(PropertyUtilityTest.class, "test.properties");
+
+    String value = PropertyUtility.getProperty("test1");
+    Assertions.assertEquals("TEST1", value);
+  }
+
+  /**
+   * Test adding a non existent or a null properties file.
+   */
+  @Test
+  void testAddPropertyFileWithInvalidInputs() {
+    // Non existent properties file
+    Assertions.assertThrows(
+        NullPointerException.class,
+        () ->
+            PropertyUtility.addPropertyFile(PropertyUtilityTest.class, "test_invalid.properties")
+    );
+    // Null inputs
+    //noinspection ConstantConditions
+    Assertions.assertThrows(
+        NullPointerException.class,
+        () ->
+            PropertyUtility.addPropertyFile(null, "test.properties")
+    );
+    Assertions.assertThrows(
+        NullPointerException.class,
+        () ->
+            PropertyUtility.addPropertyFile(PropertyUtilityTest.class, null)
+    );
+  }
+
+  /**
+   * Test removing a previously added properties file.
+   *
+   * @throws IOException When there is an issue loading the properties file.
+   */
+  @Test
+  void testRemovePropertyFileWithValidInputs() throws IOException {
+    PropertyUtility.addPropertyFile(PropertyUtilityTest.class, "test_remove.properties");
+    Assertions.assertEquals("TEST3", PropertyUtility.getProperty("test3"));
+    // Attempting to remove again shouldn't throw an exception.
+    Assertions.assertDoesNotThrow(
+        () -> PropertyUtility.removePropertyFile(
+            PropertyUtilityTest.class,
+            "test_remove.properties"
+        )
+    );
+    // Attempting to retrieve a property from the removed properties should throw an exception.
+    Assertions.assertThrows(
+        NoSuchElementException.class, () -> PropertyUtility.getProperty("test3")
+    );
+  }
+
+  /**
+   * Test removing a properties file with null inputs, invalid class or a properties file that
+   * hasn't been added.
+   */
+  @Test
+  void testRemovePropertyFileForInvalidInputs() {
+    Class<String> someRandomClass = String.class;
+    // Invalid class
+    PropertyUtility.removePropertyFile(someRandomClass, "test_remove.properties");
+
+    // Null inputs
+    Assertions.assertThrows(
+        NullPointerException.class,
+        () -> PropertyUtility.removePropertyFile(null, null)
+    );
+    Assertions.assertThrows(
+        NullPointerException.class,
+        () -> PropertyUtility.removePropertyFile(PropertyUtilityTest.class, null)
+    );
+    Assertions.assertThrows(
+        NullPointerException.class,
+        () -> PropertyUtility.removePropertyFile(null, "test.properties")
+    );
+
+    // Remove properties file that hasn't been added
+    Assertions.assertDoesNotThrow(
+        () -> PropertyUtility.removePropertyFile(
+            PropertyUtilityTest.class,
+            "test_invalid.properties"
+        )
+    );
+  }
+
+  /**
+   * Test retrieving property values as a desired type.
+   */
+  @Test
+  void testGetTypedPropertyWithValidInputs() {
+    Assertions.assertEquals(
+        PropertyUtility.getTypedProperty(Byte.class, "testByte"),
+        (byte) 5
+    );
+    Assertions.assertEquals(
+        PropertyUtility.getTypedProperty(Short.class, "testShort"),
+        (short) 543
+    );
+    Assertions.assertEquals(
+        PropertyUtility.getTypedProperty(Integer.class, "testInteger"),
+        54321
+    );
+    Assertions.assertEquals(
+        PropertyUtility.getTypedProperty(Long.class, "testLong"),
+        987654321L
+    );
+    Assertions.assertEquals(
+        PropertyUtility.getTypedProperty(Boolean.class, "testBooleanFalse"),
+        false
+    );
+    Assertions.assertEquals(
+        PropertyUtility.getTypedProperty(Boolean.class, "testBooleanTrue"),
+        true
+    );
+    Assertions.assertEquals(
+        PropertyUtility.getTypedProperty(Float.class, "testFloat"),
+        (float) -90.234
+    );
+    Assertions.assertEquals(
+        PropertyUtility.getTypedProperty(Double.class, "testDouble"),
+        -90.234234
+    );
+  }
+
+  /**
+   * Test retrieving property values as a desired type with null inputs or unsupported type classes.
+   */
+  @Test
+  void testGetTypedPropertyWithInvalidInputs() {
+    // Unsupported type class
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> PropertyUtility.getTypedProperty(String.class, "test1")
+    );
+
+    // Null inputs
+    Assertions.assertThrows(
+        NullPointerException.class,
+        () -> PropertyUtility.getTypedProperty(null, null)
+    );
+    Assertions.assertThrows(
+        NullPointerException.class,
+        () -> PropertyUtility.getTypedProperty(null, "test1")
+    );
+    Assertions.assertThrows(
+        NullPointerException.class,
+        () -> PropertyUtility.getTypedProperty(Integer.class, null)
+    );
+  }
+}

--- a/src/test/java/tests/WordCounterTest.java
+++ b/src/test/java/tests/WordCounterTest.java
@@ -1,5 +1,6 @@
 package tests;
 
+import java.io.IOException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.converter.ConvertWith;
@@ -32,6 +33,7 @@ public class WordCounterTest {
    *
    * @param str Invalid string input.
    * @param expectedWordCount Expected word count.
+   * @throws IOException When there is an issue loading the properties file.
    */
   @ParameterizedTest
   @CsvSource({
@@ -42,7 +44,7 @@ public class WordCounterTest {
       "'The little brown fox\rjumped over the lazy dog', 9",
       "'The little brown fox\njumped over the lazy dog', 9",
   })
-  public void testGetWordCount(String str, long expectedWordCount) {
+  public void testGetWordCount(String str, long expectedWordCount) throws IOException {
     Assertions.assertEquals(expectedWordCount, WordCounter.getWordCount(str));
   }
 }

--- a/src/test/resources/tests/test.properties
+++ b/src/test/resources/tests/test.properties
@@ -1,0 +1,9 @@
+test1=TEST1
+testByte=5
+testShort=543
+testInteger=54321
+testLong=987654321
+testBooleanFalse=false
+testBooleanTrue=true
+testFloat=-90.234
+testDouble=-90.234234

--- a/src/test/resources/tests/test_remove.properties
+++ b/src/test/resources/tests/test_remove.properties
@@ -1,0 +1,1 @@
+test3=TEST3


### PR DESCRIPTION
Closes #4.
The property utility can be used to load properties from pre-specified property files.
It can also load property values casted into a desired primitive (boxed) type.