### PR TITLE
Added static code analysis checks via pmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@
 This project is to serve as a parent maven project to enforce the following good practices and
 provide commonly used functionality:
  - Checkstyle enforcement as per the Google java styling guide.
+ - PMD static code analysis to enforce good practices.
  - Java code coverage check enforcement.
  - Property Utility - To read properties from files.
  - Internationalization Utility - To use internationalized strings.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.java</groupId>
     <artifactId>popper</artifactId>
-    <version>2021.01.03</version>
+    <version>2021.01.05</version>
 
     <properties>
         <maven.compiler.target>14</maven.compiler.target>
@@ -141,6 +141,26 @@
                             <excludes>
                             </excludes>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>3.14.0</version>
+                <configuration>
+                    <linkXRef>false</linkXRef>
+                    <rulesets>
+                        <ruleset>/category/java/bestpractices.xml/SystemPrintln</ruleset>
+                        <ruleset>/category/java/bestpractices.xml/AvoidPrintStackTrace</ruleset>
+                    </rulesets>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                            <goal>cpd-check</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/src/main/java/utilities/PropertyUtility.java
+++ b/src/main/java/utilities/PropertyUtility.java
@@ -101,15 +101,14 @@ public class PropertyUtility {
   public static synchronized void addPropertyFile(Class<?> cls, String propertyFileName)
       throws IOException {
     Properties properties;
-    try (final InputStream inputStream = cls.getResourceAsStream(propertyFileName)) {
+    try (InputStream inputStream = cls.getResourceAsStream(propertyFileName)) {
       properties = new Properties();
       properties.load(inputStream);
     }
     classToPropertyFilesMap.putIfAbsent(cls, new HashMap<>());
     HashMap<String, Properties> propertiesForSpecificClassMap = classToPropertyFilesMap.get(cls);
     if (propertiesForSpecificClassMap.containsKey(propertyFileName)) {
-      logger.warn("Adding a property file (" + propertyFileName + ") "
-          + "again using class (" + cls + ")");
+      logger.warn("Adding a property file ({}) again using class ({}})", propertyFileName, cls);
     }
     propertiesForSpecificClassMap.put(propertyFileName, properties);
   }
@@ -126,16 +125,13 @@ public class PropertyUtility {
     Objects.requireNonNull(propertyFileName);
 
     if (!classToPropertyFilesMap.containsKey(cls)) {
-      logger.warn("No property files loaded for the specified class (" + cls + ")");
+      logger.warn("No property files loaded for the specified class ({})", cls);
     } else {
       HashMap<String, Properties> propertiesForSpecificClassMap = classToPropertyFilesMap.get(cls);
       if (!propertiesForSpecificClassMap.containsKey(propertyFileName)) {
-        logger.warn(
-            "Specified property file ("
-                + propertyFileName
-                + ") hasn't been loaded for the specified class ("
-                + cls
-                + "). Hence it cannot be removed.");
+        String warningMessage = "Specified property file ({}) hasn't been loaded for the "
+            + "specified class ({}). Hence it cannot be removed.";
+        logger.warn(warningMessage, propertyFileName, cls);
       } else {
         propertiesForSpecificClassMap.remove(propertyFileName);
       }


### PR DESCRIPTION
Closes #19.
The PMD maven plugin has been configured to enforce fail if any of the
following rules are violated:
 - No System.out/System.err statements.
 - No .printStackTrace() statements.
 - Default rules which can be found here:
   https://maven.apache.org/plugins/maven-pmd-plugin/examples/usingRuleSets.html