### PR TITLE
Change path of the PMD ruleset file to a url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
                     <linkXRef>false</linkXRef>
                     <includeTests>true</includeTests>
                     <rulesets>
-                        <ruleset>${project.basedir}/pmd_rules.xml</ruleset>
+                        <ruleset>https://raw.githubusercontent.com/padaiyal/jPopper/main/pmd_rules.xml</ruleset>
                     </rulesets>
                 </configuration>
                 <executions>


### PR DESCRIPTION
## Description
Using absolute paths for retrieving PMD rules fails when packaging from child Maven projects. Use link to ruleset in main repository instead.

Closes #45.

## Author's Checklist
- [x] **These changes don't break existing dependants.** If they do, and you suggest to proceed, 
please explain why.

## Reviewer's Checklist
- [x] **All classes have documentation comments.**
      N/A
- [x] **All methods have documentation comments.**
      N/A
- [x] **No parameters are hardcoded.** Should be loaded as properties instead. If there needs to be hardcoded properties, explain why.
      N/A
- [x] **All information to be logged/displayed to the user are internationalized.** If not, explain why. 
      N/A
- [x] **README.md has been updated if needed.**
      N/A

## Assignee's Checklist
- [x] **All GitHub action checks have passed.**
- [x] **All reviewers have approved.**
- [x] **Relevant documentation has been updated if needed.**