### PR TITLE
Fixed an issue where the PMD checks weren't printing the errors.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.padaiyal</groupId>
     <artifactId>popper</artifactId>
-    <version>2021.01.22</version>
+    <version>2021.12.15</version>
     <packaging>pom</packaging>
 
     <url>https://github.com/padaiyal/jPopper.git</url>
@@ -165,6 +165,7 @@
                     <rulesets>
                         <ruleset>https://raw.githubusercontent.com/padaiyal/jPopper/main/pmd_rules.xml</ruleset>
                     </rulesets>
+                    <printFailingErrors>true</printFailingErrors>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
## Description
Closes #56.
Henceforth, PMD checks will print the failing errors with the points of
failure.

## Author's Checklist
- [x] **These changes don't break existing dependants.** If they do, and you suggest to proceed, 
please explain why.

## Reviewer's Checklist
- [ ] **All classes have documentation comments.** N/A
- [ ] **All methods have documentation comments.** N/A
- [ ] **No parameters are hardcoded.** Should be loaded as properties instead. If there needs to be hardcoded properties, explain why. N/A
- [ ] **All information to be logged/displayed to the user are internationalized.** If not, explain why.  N/A
- [ ] **README.md has been updated if needed.** N/A

## Assignee's Checklist
- [x] **All GitHub action checks have passed.**
- [x] **All reviewers have approved.**
- [x] **Relevant documentation has been updated if needed.**